### PR TITLE
Provisioner should upgrade apt instead of update 2x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ resource "aws_instance" "rds-gw" {
     provisioner "remote-exec" {
         inline = [
 	    "sudo apt update",
-	    "sudo apt update",
+	    "sudo apt upgrade -y",
 	    "sudo apt install -y wireguard resolvconf pgbouncer postgresql-client",
             "sudo mv /tmp/wg0.conf /etc/wireguard",
 	    "sudo cp /tmp/pgbouncer.ini /etc/pgbouncer/pgbouncer.ini",


### PR DESCRIPTION
Very small fix in the provisioner. There are two apt updates in a row, but I believe you meant the second to be an upgrade.